### PR TITLE
turn off tags check, because we use auto tag after code merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ deploy:
   file: rdl_gen.zip
   on:
     repo: yahoo/parsec-rdl-gen
-    tags: true
+    tags: false


### PR DESCRIPTION
* turn off tags check when deploy, we use auto tag after code merge