### PR TITLE
Parse bool type correctly. Parse integer and bool example. Set enum type

### DIFF
--- a/cmd/rdl-gen-parsec-swagger/genSwaggerJson_test.go
+++ b/cmd/rdl-gen-parsec-swagger/genSwaggerJson_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package main
+
+import (
+	"testing"
+	"io/ioutil"
+	"encoding/json"
+	"github.com/ardielle/ardielle-go/rdl"
+	"os"
+)
+
+func TestGenerateImpl(test *testing.T) {
+	data, err := ioutil.ReadFile("../../testdata/rdl-gen-parsec-swagger/sample.json")
+	checkErrInTest(err, "can not read sample file", test)
+
+	var schema rdl.Schema
+	err = json.Unmarshal(data, &schema)
+	checkErrInTest(err, "unmarshal sample data fail", test)
+
+	genParsecError := true
+	swaggerData, err := swagger(&schema, genParsecError, "", "", "")
+	checkErrInTest(err, "cannot generate swagger", test)
+	j, err := json.MarshalIndent(swaggerData, "", "    ")
+	checkErrInTest(err, "cannot marshal swagger", test)
+
+	expectedSampleSwagger, err := ioutil.ReadFile("../../testdata/rdl-gen-parsec-swagger/swagger.json")
+	checkErrInTest(err, "cannot read swagger json file", test)
+
+	if (string(j) != string(expectedSampleSwagger)) {
+		test.Errorf("sample swagger json not generated as expected, real: \n%s\n, expected: \n%s\n",
+			string(j), string(expectedSampleSwagger))
+	}
+}
+
+func checkErrInTest(err error, msg string, test *testing.T) {
+	if err != nil {
+		test.Error(msg)
+		os.Exit(1)
+	}
+}

--- a/cmd/rdl-gen-parsec-swagger/main.go
+++ b/cmd/rdl-gen-parsec-swagger/main.go
@@ -376,7 +376,18 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 						case "Int32", "Int64", "Int16":
 							items.Type = "integer"
 							items.Format = strings.ToLower(fItems)
-							items.Example = f.Annotations[ExampleAnnotationKey]
+							if example, err:= strconv.Atoi(f.Annotations[ExampleAnnotationKey]); err == nil {
+								items.Example = example
+							} else {
+								items.Example = 0
+							}
+						case "Bool":
+							items.Type = "bool"
+							if example, err:= strconv.ParseBool(f.Annotations[ExampleAnnotationKey]); err == nil {
+								items.Example = example
+							} else {
+								items.Example = false
+							}
 						default:
 							items.Ref = "#/definitions/" + fItems
 						}
@@ -388,8 +399,19 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 				case rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeInt16:
 					prop.Type = "integer"
 					prop.Format = strings.ToLower(fbt.String())
-					prop.Example = f.Annotations[ExampleAnnotationKey]
-				case rdl.BaseTypeStruct:
+					if example, err:= strconv.Atoi(f.Annotations[ExampleAnnotationKey]); err == nil {
+						prop.Example = example
+					} else {
+						prop.Example = 0
+					}
+				case rdl.BaseTypeBool:
+					prop.Type = "bool"
+					if example, err:= strconv.ParseBool(f.Annotations[ExampleAnnotationKey]); err == nil {
+						prop.Example = example
+					} else {
+						prop.Example = false
+					}
+				case rdl.BaseTypeEnum, rdl.BaseTypeStruct:
 					prop.Ref = "#/definitions/" + string(f.Type)
 				case rdl.BaseTypeMap:
 					prop.Type = "object"
@@ -403,7 +425,18 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 						case "Int32", "Int64", "Int16":
 							items.Type = "integer"
 							items.Format = strings.ToLower(fItems)
-							items.Example = f.Annotations[ExampleAnnotationKey]
+							if example, err:= strconv.Atoi(f.Annotations[ExampleAnnotationKey]); err == nil {
+								items.Example = example
+							} else {
+								items.Example = 0
+							}
+						case "Bool":
+							items.Type = "bool"
+							if example, err:= strconv.ParseBool(f.Annotations[ExampleAnnotationKey]); err == nil {
+								items.Example = example
+							} else {
+								items.Example = false
+							}
 						default:
 							items.Ref = "#/definitions/" + fItems
 						}
@@ -444,6 +477,7 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 			tmp = append(tmp, string(el.Symbol))
 		}
 		st.Enum = tmp
+		st.Type = "string"
 	case rdl.TypeVariantUnionTypeDef:
 		typedef := t.UnionTypeDef
 		fmt.Println("[" + typedef.Name + ": Swagger doesn't support unions]")

--- a/testdata/rdl-gen-parsec-swagger/sample.json
+++ b/testdata/rdl-gen-parsec-swagger/sample.json
@@ -1,0 +1,140 @@
+{
+    "namespace": "com.example",
+    "name": "swagger",
+    "version": 1,
+    "types": [
+        {
+            "EnumTypeDef": {
+                "type": "Enum",
+                "name": "Property",
+                "elements": [
+                    {
+                        "symbol": "AUCTION",
+                        "comment": "TW Auctions"
+                    },
+                    {
+                        "symbol": "MALL",
+                        "comment": "TW MarketPlace"
+                    },
+                    {
+                        "symbol": "SHOPPING",
+                        "comment": "TW Shopping"
+                    },
+                    {
+                        "symbol": "NEVEC",
+                        "comment": "TW NEVEC"
+                    }
+                ]
+            }
+        },
+        {
+            "StructTypeDef": {
+                "type": "Struct",
+                "name": "Order",
+                "annotations": {
+                    "x_object": ""
+                },
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "String"
+                    }
+                ]
+            }
+        },
+        {
+            "StructTypeDef": {
+                "type": "Struct",
+                "name": "Response",
+                "fields": [
+                    {
+                        "name": "property",
+                        "type": "Property",
+                        "annotations": {
+                            "x_not_null": ""
+                        }
+                    },
+                    {
+                        "name": "properties",
+                        "type": "Array",
+                        "items": "Property"
+                    },
+                    {
+                        "name": "userId",
+                        "type": "String"
+                    },
+                    {
+                        "name": "userIds",
+                        "type": "Array",
+                        "items": "String"
+                    },
+                    {
+                        "name": "order",
+                        "type": "Order",
+                        "annotations": {
+                            "x_must_validate": "",
+                            "x_not_null": ""
+                        }
+                    },
+                    {
+                        "name": "orders",
+                        "type": "Array",
+                        "items": "Order"
+                    },
+                    {
+                        "name": "recommendFuture",
+                        "type": "Bool"
+                    },
+                    {
+                        "name": "recommendFutures",
+                        "type": "Array",
+                        "items": "Bool"
+                    },
+                    {
+                        "name": "num",
+                        "type": "Int32"
+                    },
+                    {
+                        "name": "nums",
+                        "type": "Array",
+                        "items": "Int32"
+                    }
+                ]
+            }
+        }
+    ],
+    "resources": [
+        {
+            "type": "Response",
+            "method": "GET",
+            "path": "/get/{id}",
+            "inputs": [
+                {
+                    "name": "id",
+                    "type": "String",
+                    "pathParam": true,
+                    "optional": true
+                }
+            ],
+            "expected": "OK",
+            "exceptions": {
+                "BAD_REQUEST": {
+                    "type": "ResourceError"
+                },
+                "FORBIDDEN": {
+                    "type": "ResourceError"
+                },
+                "INTERNAL_SERVER_ERROR": {
+                    "type": "ResourceError"
+                },
+                "NOT_FOUND": {
+                    "type": "ResourceError"
+                },
+                "UNAUTHORIZED": {
+                    "type": "ResourceError"
+                }
+            },
+            "name": "getId"
+        }
+    ]
+}

--- a/testdata/rdl-gen-parsec-swagger/swagger.json
+++ b/testdata/rdl-gen-parsec-swagger/swagger.json
@@ -1,0 +1,216 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "The swagger API",
+        "version": "1"
+    },
+    "basePath": "/swagger/v1",
+    "schemes": [],
+    "paths": {
+        "/get/{id}": {
+            "get": {
+                "tags": [
+                    "Response"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "type": "string",
+                        "required": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ResourceError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ResourceError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ResourceError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ResourceError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ResourceError"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Order": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": ""
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "ParsecErrorBody": {
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "detail": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ParsecErrorDetail"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "message"
+            ]
+        },
+        "ParsecErrorDetail": {
+            "properties": {
+                "invalidValue": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "message"
+            ]
+        },
+        "ParsecResourceError": {
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/ParsecErrorBody"
+                }
+            },
+            "required": [
+                "error"
+            ]
+        },
+        "Property": {
+            "type": "string",
+            "enum": [
+                "AUCTION",
+                "MALL",
+                "SHOPPING",
+                "NEVEC"
+            ]
+        },
+        "ResourceError": {
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "Response": {
+            "properties": {
+                "num": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 0
+                },
+                "nums": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "example": 0
+                    }
+                },
+                "order": {
+                    "$ref": "#/definitions/Order"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Order"
+                    }
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Property"
+                    }
+                },
+                "property": {
+                    "$ref": "#/definitions/Property"
+                },
+                "recommendFuture": {
+                    "type": "bool",
+                    "example": false
+                },
+                "recommendFutures": {
+                    "type": "array",
+                    "items": {
+                        "type": "bool",
+                        "example": false
+                    }
+                },
+                "userId": {
+                    "type": "string",
+                    "example": ""
+                },
+                "userIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "example": ""
+                    }
+                }
+            },
+            "required": [
+                "property",
+                "properties",
+                "userId",
+                "userIds",
+                "order",
+                "orders",
+                "recommendFuture",
+                "recommendFutures",
+                "num",
+                "nums"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
to string, it is required to make enum visible in swagger.