### PR TITLE
Support null parameters in java client

### DIFF
--- a/cmd/rdl-gen-parsec-java-client/gentemplate_test.go
+++ b/cmd/rdl-gen-parsec-java-client/gentemplate_test.go
@@ -106,9 +106,8 @@ func TestUriConstruct(test *testing.T) {
 	inputs := []*rdl.ResourceInput{{Name: "id", PathParam: true}}
 	r := &rdl.Resource{Inputs: inputs}
 	realOut := gen.builderExt(r)
-	expectedOut := `
-                            .resolveTemplate("id", id)
-                            .build();`
+	expectedOut := `        xUriBuilder.resolveTemplate("id", id);
+`
 	if realOut != expectedOut {
 		test.Errorf("uri builder not generate as expected: real: \n%s\n, expected: \n%s\n",
 			realOut, expectedOut)

--- a/cmd/rdl-gen-parsec-java-client/main.go
+++ b/cmd/rdl-gen-parsec-java-client/main.go
@@ -146,6 +146,7 @@ func (gen *javaClientGenerator) processTemplate(templateSource string) error {
 		"name":        func() string { return gen.name },
 		"cName":       func() string { return utils.Capitalize(gen.name) },
 		"lName":       func() string { return utils.Uncapitalize(gen.name) },
+		"basePath":    func() string { return utils.JavaGenerationRootPath(gen.schema) },
 		"needBody":    needBodyFunc,
 		"bodyObj":     func(r *rdl.Resource) string { return gen.getBodyObj(r) },
 		"iMethodWithHeader":
@@ -353,7 +354,7 @@ public class {{cName}}ClientImpl implements {{cName}}Client {
 
     @Override
     {{methodSigWithHeader .}} {
-        String xPath = "{{.Path}}";
+        String xPath = "/api{{basePath}}{{.Path}}";
         String xBody = null;
 {{if needBody .}}
         try {

--- a/cmd/rdl-gen-parsec-java-client/main.go
+++ b/cmd/rdl-gen-parsec-java-client/main.go
@@ -164,17 +164,18 @@ func (gen *javaClientGenerator) processTemplate(templateSource string) error {
 }
 
 func (gen* javaClientGenerator) builderExt(r *rdl.Resource) string {
-	code := "\n"
-	spacePad := "                            "
+	code := ""
+	spacePad := "        "
 	for _, input := range r.Inputs {
 		iname := javaName(input.Name)
 		if input.PathParam {
-			code += spacePad + ".resolveTemplate(\"" + iname + "\", " + iname + ")\n"
+			code += spacePad + "xUriBuilder.resolveTemplate(\"" + iname + "\", " + iname + ");\n"
 		} else if input.QueryParam != "" {
-			code += spacePad + ".queryParam(\"" + iname + "\", " + iname + ")\n"
+			code += spacePad + "if (" + iname + " != null) {\n"
+			code += spacePad + "    xUriBuilder.queryParam(\"" + iname + "\", " + iname + ");\n"
+			code += spacePad + "}\n"
 		}
 	}
-	code += spacePad + ".build();"
 	return code
 }
 
@@ -362,7 +363,8 @@ public class {{cName}}ClientImpl implements {{cName}}Client {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR, e.getMessage());
         }
 {{end}}
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath){{builderExt .}}
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+{{builderExt .}}        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -403,7 +405,7 @@ func javaMethodName(reg rdl.TypeRegistry, r *rdl.Resource, needParamWithType boo
 		if v.QueryParam == "" && !v.PathParam && v.Header == "" {
 			bodyType = string(safeTypeVarName(v.Type))
 		}
-		optional := false // but different with server code, how?
+		optional := true
 		if (needParamWithType) {
 			params = append(params, utils.JavaType(reg, v.Type, optional, "", "") + " " + javaName(k))
 		} else {

--- a/cmd/rdl-gen-parsec-java-client/main.go
+++ b/cmd/rdl-gen-parsec-java-client/main.go
@@ -146,7 +146,6 @@ func (gen *javaClientGenerator) processTemplate(templateSource string) error {
 		"name":        func() string { return gen.name },
 		"cName":       func() string { return utils.Capitalize(gen.name) },
 		"lName":       func() string { return utils.Uncapitalize(gen.name) },
-		"basePath":    func() string { return utils.JavaGenerationRootPath(gen.schema) },
 		"needBody":    needBodyFunc,
 		"bodyObj":     func(r *rdl.Resource) string { return gen.getBodyObj(r) },
 		"iMethodWithHeader":
@@ -354,7 +353,7 @@ public class {{cName}}ClientImpl implements {{cName}}Client {
 
     @Override
     {{methodSigWithHeader .}} {
-        String xPath = "/api{{basePath}}{{.Path}}";
+        String xPath = "{{.Path}}";
         String xBody = null;
 {{if needBody .}}
         try {

--- a/testdata/Sample2ClientImpl.txt
+++ b/testdata/Sample2ClientImpl.txt
@@ -128,18 +128,18 @@ public class SampleClientImpl implements SampleClient {
     }
 
     @Override
-    public CompletableFuture<User> getUserId(int id) throws ResourceException {
+    public CompletableFuture<User> getUserId(Integer id) throws ResourceException {
         return getUserId(null, id);
     }
 
     @Override
-    public CompletableFuture<User> getUserId(Map<String, List<String>> headers, int id) throws ResourceException {
+    public CompletableFuture<User> getUserId(Map<String, List<String>> headers, Integer id) throws ResourceException {
         String xPath = "/user/{id}";
         String xBody = null;
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .resolveTemplate("id", id)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        xUriBuilder.resolveTemplate("id", id);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -161,8 +161,8 @@ public class SampleClientImpl implements SampleClient {
         String xPath = "/wssid";
         String xBody = null;
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }

--- a/testdata/SampleClient.txt
+++ b/testdata/SampleClient.txt
@@ -14,14 +14,14 @@ import com.example.parsec_generated.Users;
 
 public interface SampleClient {
 
-    CompletableFuture<User> getUser(int id) throws ResourceException;
-    CompletableFuture<User> getUser(Map<String, List<String>> headers, int id) throws ResourceException;
+    CompletableFuture<User> getUser(Integer id) throws ResourceException;
+    CompletableFuture<User> getUser(Map<String, List<String>> headers, Integer id) throws ResourceException;
     CompletableFuture<User> postUser(User user) throws ResourceException;
     CompletableFuture<User> postUser(Map<String, List<String>> headers, User user) throws ResourceException;
-    CompletableFuture<User> putUser(int id, User user) throws ResourceException;
-    CompletableFuture<User> putUser(Map<String, List<String>> headers, int id, User user) throws ResourceException;
-    CompletableFuture<User> deleteUser(int id) throws ResourceException;
-    CompletableFuture<User> deleteUser(Map<String, List<String>> headers, int id) throws ResourceException;
+    CompletableFuture<User> putUser(Integer id, User user) throws ResourceException;
+    CompletableFuture<User> putUser(Map<String, List<String>> headers, Integer id, User user) throws ResourceException;
+    CompletableFuture<User> deleteUser(Integer id) throws ResourceException;
+    CompletableFuture<User> deleteUser(Map<String, List<String>> headers, Integer id) throws ResourceException;
     CompletableFuture<Users> getUsers(String ids) throws ResourceException;
     CompletableFuture<Users> getUsers(Map<String, List<String>> headers, String ids) throws ResourceException;
 }

--- a/testdata/SampleClientImpl.txt
+++ b/testdata/SampleClientImpl.txt
@@ -131,18 +131,18 @@ public class SampleClientImpl implements SampleClient {
     }
 
     @Override
-    public CompletableFuture<User> getUser(int id) throws ResourceException {
+    public CompletableFuture<User> getUser(Integer id) throws ResourceException {
         return getUser(null, id);
     }
 
     @Override
-    public CompletableFuture<User> getUser(Map<String, List<String>> headers, int id) throws ResourceException {
+    public CompletableFuture<User> getUser(Map<String, List<String>> headers, Integer id) throws ResourceException {
         String xPath = "/user/{id}";
         String xBody = null;
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .resolveTemplate("id", id)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        xUriBuilder.resolveTemplate("id", id);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -171,8 +171,8 @@ public class SampleClientImpl implements SampleClient {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR, e.getMessage());
         }
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -188,12 +188,12 @@ public class SampleClientImpl implements SampleClient {
     }
 
     @Override
-    public CompletableFuture<User> putUser(int id, User user) throws ResourceException {
+    public CompletableFuture<User> putUser(Integer id, User user) throws ResourceException {
         return putUser(null, id, user);
     }
 
     @Override
-    public CompletableFuture<User> putUser(Map<String, List<String>> headers, int id, User user) throws ResourceException {
+    public CompletableFuture<User> putUser(Map<String, List<String>> headers, Integer id, User user) throws ResourceException {
         String xPath = "/user/{id}";
         String xBody = null;
 
@@ -204,9 +204,9 @@ public class SampleClientImpl implements SampleClient {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR, e.getMessage());
         }
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .resolveTemplate("id", id)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        xUriBuilder.resolveTemplate("id", id);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -219,18 +219,18 @@ public class SampleClientImpl implements SampleClient {
     }
 
     @Override
-    public CompletableFuture<User> deleteUser(int id) throws ResourceException {
+    public CompletableFuture<User> deleteUser(Integer id) throws ResourceException {
         return deleteUser(null, id);
     }
 
     @Override
-    public CompletableFuture<User> deleteUser(Map<String, List<String>> headers, int id) throws ResourceException {
+    public CompletableFuture<User> deleteUser(Map<String, List<String>> headers, Integer id) throws ResourceException {
         String xPath = "/user/{id}";
         String xBody = null;
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .resolveTemplate("id", id)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        xUriBuilder.resolveTemplate("id", id);
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }
@@ -256,9 +256,11 @@ public class SampleClientImpl implements SampleClient {
         String xPath = "/users";
         String xBody = null;
 
-        URI xUri = UriBuilder.fromUri(this.url).path(xPath)
-                            .queryParam("ids", ids)
-                            .build();
+        UriBuilder xUriBuilder = UriBuilder.fromUri(this.url).path(xPath);
+        if (ids != null) {
+            xUriBuilder.queryParam("ids", ids);
+        }
+        URI xUri = xUriBuilder.build();
         if (headers == null) {
             headers = getDefaultHeaders();
         }


### PR DESCRIPTION
Since JerseyUriBuilder does not support null values in queryParam(), let java client check if parameter is null in advance.