### PR TITLE
support map of type object in swagger

### DIFF
--- a/cmd/rdl-gen-parsec-swagger/main.go
+++ b/cmd/rdl-gen-parsec-swagger/main.go
@@ -497,6 +497,23 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 			}
 			st.Items = items
 		}
+	case rdl.TypeVariantMapTypeDef:
+		typedef := t.MapTypeDef
+		st.Type = "object"
+		if typedef.Items != "Any" {
+			tItems := string(typedef.Items)
+			items := new(SwaggerType)
+			switch reg.FindBaseType(typedef.Items) {
+			case rdl.BaseTypeString:
+				items.Type = strings.ToLower(tItems)
+			case rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeInt16:
+				items.Type = "integer"
+				items.Format = strings.ToLower(tItems)
+			default:
+				items.Ref = "#/definitions/" + tItems
+			}
+			st.AdditionalProperties = items
+		}
 	case rdl.TypeVariantEnumTypeDef:
 		typedef := t.EnumTypeDef
 		var tmp []string

--- a/testdata/rdl-gen-parsec-swagger/multipleType.json
+++ b/testdata/rdl-gen-parsec-swagger/multipleType.json
@@ -43,6 +43,14 @@
             }
         },
         {
+            "MapTypeDef": {
+                "type": "Map",
+                "name": "ResizedImageMap",
+                "keys": "String",
+                "items": "String"
+            }
+        },
+        {
             "StructTypeDef": {
                 "type": "Struct",
                 "name": "Response",
@@ -98,6 +106,11 @@
                         "name": "respNums",
                         "type": "Array",
                         "items": "Int32"
+                    },
+                    {
+                        "name": "resizedImages",
+                        "type": "Array",
+                        "items": "ResizedImageMap"
                     }
                 ]
             }

--- a/testdata/rdl-gen-parsec-swagger/multipleType.rdl.backup
+++ b/testdata/rdl-gen-parsec-swagger/multipleType.rdl.backup
@@ -13,6 +13,8 @@ type Order struct (x_object) {
     string name;
 }
 
+type ResizedImageMap Map<String,String>;
+
 type Response struct {
     Property respProperty (x_not_null);
 
@@ -33,6 +35,8 @@ type Response struct {
     int32 respNum;
 
     array<int32> respNums;
+
+    array<ResizedImageMap> resizedImages;
 }
 
 

--- a/testdata/rdl-gen-parsec-swagger/multipleType_swagger.json
+++ b/testdata/rdl-gen-parsec-swagger/multipleType_swagger.json
@@ -227,6 +227,12 @@
                 "reqNums"
             ]
         },
+        "ResizedImageMap": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "ResourceError": {
             "properties": {
                 "code": {
@@ -296,6 +302,12 @@
                         "format": "int32",
                         "example": 0
                     }
+                },
+                "resizedImages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ResizedImageMap"
+                    }
                 }
             },
             "required": [
@@ -308,7 +320,8 @@
                 "respRecommendFuture",
                 "respRecommendFutures",
                 "respNum",
-                "respNums"
+                "respNums",
+                "resizedImages"
             ]
         }
     }


### PR DESCRIPTION
**Issue #, if available:**
generate swagger schema error if there is any map of type object is defined in rdl

**Description of changes:**
support map of type object in swagger

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
