### PR TITLE
use another import path for AbstractBinder

### DIFF
--- a/cmd/rdl-gen-parsec-java-server/main.go
+++ b/cmd/rdl-gen-parsec-java-server/main.go
@@ -655,7 +655,7 @@ package {{package}};
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

After Jersey 2.26 release, the hk2 part has been decoupled from Jersey's DI mechanism, hens the import paths that references hk2.utilities.binding will be moved to jersey.internal.inject (See https://jersey.github.io/release-notes/2.26.html ). For further usage, the parsec-rdl-gen should change the corresponding templates as well.