### PR TITLE
Revert "use another import path for AbstractBinder"

### DIFF
--- a/cmd/rdl-gen-parsec-java-server/main.go
+++ b/cmd/rdl-gen-parsec-java-server/main.go
@@ -655,7 +655,7 @@ package {{package}};
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 


### PR DESCRIPTION
Reverts yahoo/parsec-rdl-gen#72